### PR TITLE
Update PDF for hearing arrangements section

### DIFF
--- a/src/main/resources/templates/appellant_appeal_template.html
+++ b/src/main/resources/templates/appellant_appeal_template.html
@@ -314,10 +314,27 @@
         </div>
 
         <div>
-            <dt class="cya-question">Disabled access</dt>
+            <dt class="cya-question">Accessible hearing room</dt>
             <dd class="cya-answer">
-                {{ SyaCaseWrapper.hearing.arrangements is defined and SyaCaseWrapper.hearing.arrangements.disabledAccess == true ? "Yes" : "No" }}, disabled access required
+                {{ SyaCaseWrapper.hearing.arrangements is defined and SyaCaseWrapper.hearing.arrangements.accessibleHearingRoom == true ? "Yes" : "No" }}, accessible hearing room required
             </dd>
+        </div>
+
+        <div>
+            <dt class="cya-question">Other</dt>
+            <dd class="cya-answer">
+                {{ SyaCaseWrapper.hearing.arrangements is defined and SyaCaseWrapper.hearing.arrangements.other == true ? "Yes" : "No" }}, other support required
+            </dd>
+        </div>
+
+        <div>
+            <dt class="cya-question">Language interpreter type</dt>
+            <dd class="cya-answer">{{ SyaCaseWrapper.hearing.interpreterLanguageType | default('None') }}</dd>
+        </div>
+
+        <div>
+            <dt class="cya-question">Sign language type</dt>
+            <dd class="cya-answer">{{ SyaCaseWrapper.hearing.signLanguageType | default('None') }}</dd>
         </div>
 
         <div>

--- a/src/main/resources/templates/appellant_appeal_template.html
+++ b/src/main/resources/templates/appellant_appeal_template.html
@@ -295,51 +295,60 @@
         <div>
             <dt class="cya-question">Language interpreter</dt>
             <dd class="cya-answer">
-                {{ SyaCaseWrapper.hearing.arrangements is defined and SyaCaseWrapper.hearing.arrangements.languageInterpreter == true ? "Yes" : "No" }}, language interpreter required
+                {% if SyaCaseWrapper.hearing.arrangements is defined and SyaCaseWrapper.hearing.arrangements.languageInterpreter == true %}
+                    {% if SyaCaseWrapper.hearing.interpreterLanguageType is defined and SyaCaseWrapper.hearing.interpreterLanguageType != '' %}
+                        {{ SyaCaseWrapper.hearing.interpreterLanguageType }}
+                    {% else %}
+                        Required
+                    {% endif %}
+                {% else %}
+                    Not required
+                {% endif %}
             </dd>
         </div>
 
         <div>
             <dt class="cya-question">Sign language interpreter</dt>
             <dd class="cya-answer">
-                {{ SyaCaseWrapper.hearing.arrangements is defined and SyaCaseWrapper.hearing.arrangements.signLanguageInterpreter == true ? "Yes" : "No" }}, sign language interpreter required
+                {% if SyaCaseWrapper.hearing.arrangements is defined and SyaCaseWrapper.hearing.arrangements.signLanguageInterpreter == true %}
+                    {% if SyaCaseWrapper.hearing.signLanguageType is defined and SyaCaseWrapper.hearing.signLanguageType != '' %}
+                        {{ SyaCaseWrapper.hearing.signLanguageType }}
+                    {% else %}
+                        Required
+                    {% endif %}
+                {% else %}
+                    Not required
+                {% endif %}
             </dd>
         </div>
 
         <div>
             <dt class="cya-question">Hearing loop</dt>
             <dd class="cya-answer">
-                {{ SyaCaseWrapper.hearing.arrangements is defined and SyaCaseWrapper.hearing.arrangements.hearingLoop == true ? "Yes" : "No" }}, hearing loop required
+                {{ SyaCaseWrapper.hearing.arrangements is defined and SyaCaseWrapper.hearing.arrangements.hearingLoop == true ? "Required" : "Not required" }}
             </dd>
         </div>
 
         <div>
             <dt class="cya-question">Accessible hearing room</dt>
             <dd class="cya-answer">
-                {{ SyaCaseWrapper.hearing.arrangements is defined and SyaCaseWrapper.hearing.arrangements.accessibleHearingRoom == true ? "Yes" : "No" }}, accessible hearing room required
+                {{ SyaCaseWrapper.hearing.arrangements is defined and SyaCaseWrapper.hearing.arrangements.accessibleHearingRoom == true ? "Required" : "Not required" }}
             </dd>
-        </div>
-
-        <div>
-            <dt class="cya-question">Other</dt>
-            <dd class="cya-answer">
-                {{ SyaCaseWrapper.hearing.arrangements is defined and SyaCaseWrapper.hearing.arrangements.other == true ? "Yes" : "No" }}, other support required
-            </dd>
-        </div>
-
-        <div>
-            <dt class="cya-question">Language interpreter type</dt>
-            <dd class="cya-answer">{{ SyaCaseWrapper.hearing.interpreterLanguageType | default('None') }}</dd>
-        </div>
-
-        <div>
-            <dt class="cya-question">Sign language type</dt>
-            <dd class="cya-answer">{{ SyaCaseWrapper.hearing.signLanguageType | default('None') }}</dd>
         </div>
 
         <div>
             <dt class="cya-question">Any other arrangements</dt>
-            <dd class="cya-answer">{{ SyaCaseWrapper.hearing.anythingElse | default('None') }}</dd>
+            <dd class="cya-answer">
+                {% if SyaCaseWrapper.hearing.arrangements is defined and SyaCaseWrapper.hearing.arrangements.other == true %}
+                    {% if SyaCaseWrapper.hearing.anythingElse is defined and SyaCaseWrapper.hearing.anythingElse != '' %}
+                        {{ SyaCaseWrapper.hearing.anythingElse }}
+                    {% else %}
+                        Required
+                    {% endif %}
+                {% else %}
+                    Not required
+                {% endif %}
+            </dd>
         </div>
     </dl>
 


### PR DESCRIPTION
- Add new fields `interpreterLanguageType`, `signLanguageType`
- Add other `option`
- Change `disabledAccess` to `accessibleHearingRoom`

**Example:**
- If `sign language interpreter` has been selected and the `signLanguageType` field has a value then display that value else display `Required`. Display `Not required` when sign language interpreter hasn't been selected.