### PR TITLE
SSCS-2877 User id extracted from IDAM authorization token

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       IDAM_OAUTH2_CLIENT_SECRET: QM5RQQ53LZFOSIXJ
       IDAM_SSCS_URL: https://localhost:9000/poc
       CORE_CASE_DATA_API_URL: http://localhost:4452
-      CORE_CASE_DATA_USER_ID: 16
       CORE_CASE_DATA_JURISDICTION_ID: SSCS
       CORE_CASE_DATA_CASE_TYPE_ID: Benefit
     ports:

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,3 +1,2 @@
 idam_redirect_url = "https://evidence-sharing-preprod.sscs.reform.hmcts.net"
 infrastructure_env = "preprod"
-core_case_data_user_id = "506"

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,3 +1,2 @@
 idam_redirect_url = "https://evidence-sharing-preprod.sscs.reform.hmcts.net"
 infrastructure_env = "preprod"
-core_case_data_user_id = "506"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -126,7 +126,6 @@ module "tribunals-case-api" {
     SUBSCRIPTIONS_MAC_SECRET="${data.vault_generic_secret.email_mac_secret.data["value"]}"
 
     CORE_CASE_DATA_API_URL = "${local.ccdApi}"
-    CORE_CASE_DATA_USER_ID = "${var.core_case_data_user_id}"
     CORE_CASE_DATA_JURISDICTION_ID = "${var.core_case_data_jurisdiction_id}"
     CORE_CASE_DATA_CASE_TYPE_ID = "${var.core_case_data_case_type_id}"
     CORE_CASE_DATA_EVENT_ID = "${var.core_case_data_event_id}"

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -1,3 +1,2 @@
 idam_redirect_url = "https://evidence-sharing-preprod.sscs.reform.hmcts.net"
 infrastructure_env = "preprod"
-core_case_data_user_id = "506"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,3 +1,2 @@
 infrastructure_env = "prod"
 idam_redirect_url = "https://sscs-case-loader-prod.service.core-compute-prod.internal"
-core_case_data_user_id = "11289"

--- a/infrastructure/sandbox.tfvars
+++ b/infrastructure/sandbox.tfvars
@@ -1,3 +1,2 @@
 infrastructure_env = "test"
-core_case_data_user_id = "43132"
 idam_redirect_url = "https://sscs-case-loader-aat.service.core-compute-aat.internal"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -51,10 +51,6 @@ variable "idam_s2s_auth_microservice" {
   default = "cmc"
 }
 
-variable "core_case_data_user_id"{
-  default = "16"
-}
-
 variable "core_case_data_jurisdiction_id"{
   default = "SSCS"
 }

--- a/src/IntegrationTests/java/uk/gov/hmcts/sscs/ccd/properties/CoreCaseDataPropertiesTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/sscs/ccd/properties/CoreCaseDataPropertiesTest.java
@@ -8,8 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import uk.gov.hmcts.sscs.ccd.properties.CoreCaseDataProperties;
-
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class CoreCaseDataPropertiesTest {
@@ -19,7 +17,6 @@ public class CoreCaseDataPropertiesTest {
 
     @Test
     public void givenAnInstanceOfCcdProperties_shouldContainCcdValues() {
-        assertNotNull(coreCaseDataProperties.getUserId());
         assertNotNull(coreCaseDataProperties.getJurisdictionId());
         assertNotNull(coreCaseDataProperties.getCaseTypeId());
         assertNotNull(coreCaseDataProperties.getApi().getUrl());

--- a/src/IntegrationTests/java/uk/gov/hmcts/sscs/sya/SyaEndpointsIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/sscs/sya/SyaEndpointsIt.java
@@ -57,6 +57,7 @@ import uk.gov.hmcts.sscs.controller.SyaController;
 import uk.gov.hmcts.sscs.domain.wrapper.SyaCaseWrapper;
 import uk.gov.hmcts.sscs.model.idam.Authorize;
 import uk.gov.hmcts.sscs.model.pdf.PdfWrapper;
+import uk.gov.hmcts.sscs.service.idam.AuthTokenSubjectExtractor;
 import uk.gov.hmcts.sscs.service.idam.IdamApiClient;
 
 @RunWith(SpringRunner.class)
@@ -81,6 +82,9 @@ public class SyaEndpointsIt {
 
     @MockBean
     private JavaMailSender mailSender;
+
+    @MockBean
+    private AuthTokenSubjectExtractor authTokenSubjectExtractor;
 
     @Captor
     private ArgumentCaptor captor;
@@ -130,6 +134,8 @@ public class SyaEndpointsIt {
                 .willReturn(authorize);
 
         given(authTokenGenerator.generate()).willReturn("authToken");
+
+        given(authTokenSubjectExtractor.extract(anyString())).willReturn("userId");
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/sscs/ccd/properties/CoreCaseDataProperties.java
+++ b/src/main/java/uk/gov/hmcts/sscs/ccd/properties/CoreCaseDataProperties.java
@@ -15,8 +15,7 @@ import org.springframework.validation.annotation.Validated;
 @Getter
 @Setter
 public class CoreCaseDataProperties {
-    @NotBlank
-    private String userId;
+
     @NotBlank
     private String jurisdictionId;
     @NotBlank

--- a/src/main/java/uk/gov/hmcts/sscs/service/ccd/CreateCoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/sscs/service/ccd/CreateCoreCaseDataService.java
@@ -1,59 +1,63 @@
 package uk.gov.hmcts.sscs.service.ccd;
 
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
 import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.EventRequestData;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.sscs.model.ccd.CaseData;
+import uk.gov.hmcts.sscs.service.idam.IdamService;
 
 @Service
 @Slf4j
 public class CreateCoreCaseDataService {
 
     private final CoreCaseDataService coreCaseDataService;
+    private final IdamService idamService;
 
     @Autowired
-    CreateCoreCaseDataService(CoreCaseDataService coreCaseDataService) {
+    CreateCoreCaseDataService(CoreCaseDataService coreCaseDataService,
+                              IdamService idamService) {
         this.coreCaseDataService = coreCaseDataService;
+        this.idamService = idamService;
     }
 
     public CaseDetails createCcdCase(CaseData caseData) {
         log.info("*** tribunals-service *** createCcdCase ");
         EventRequestData eventRequestData = coreCaseDataService.getEventRequestData("appealCreated");
-        String serviceAuthorization = coreCaseDataService.generateServiceAuthorization();
+        log.info("*** tribunals-service *** eventRequestData: {}", eventRequestData);
+        String serviceAuthorization = idamService.generateServiceAuthorization();
+        log.info("*** tribunals-service *** s2s token: {}", serviceAuthorization);
         StartEventResponse startEventResponse = start(eventRequestData, serviceAuthorization);
         return create(eventRequestData, serviceAuthorization, coreCaseDataService.getCaseDataContent(caseData,
-            startEventResponse, "SSCS - appeal created event", "Created SSCS"));
+                startEventResponse, "SSCS - appeal created event", "Created SSCS"));
     }
 
     private StartEventResponse start(EventRequestData eventRequestData, String serviceAuthorization) {
         log.info("*** tribunals-service *** Calling CCD (url: {}) endpoint to start Case For Caseworker...",
-            coreCaseDataService.getCcdUrl());
+                coreCaseDataService.getCcdUrl());
         return coreCaseDataService.getCoreCaseDataApi().startForCaseworker(
-            eventRequestData.getUserToken(),
-            serviceAuthorization,
-            eventRequestData.getUserId(),
-            eventRequestData.getJurisdictionId(),
-            eventRequestData.getCaseTypeId(),
-            eventRequestData.getEventId());
+                eventRequestData.getUserToken(),
+                serviceAuthorization,
+                eventRequestData.getUserId(),
+                eventRequestData.getJurisdictionId(),
+                eventRequestData.getCaseTypeId(),
+                eventRequestData.getEventId());
     }
 
     private CaseDetails create(EventRequestData eventRequestData, String serviceAuthorization,
                                CaseDataContent caseDataContent) {
         log.info("*** tribunals-service *** Calling CCD endpoint to save CaseDetails For CaseWorker...");
         return coreCaseDataService.getCoreCaseDataApi().submitForCaseworker(
-            eventRequestData.getUserToken(),
-            serviceAuthorization,
-            eventRequestData.getUserId(),
-            eventRequestData.getJurisdictionId(),
-            eventRequestData.getCaseTypeId(),
-            eventRequestData.isIgnoreWarning(),
-            caseDataContent
+                eventRequestData.getUserToken(),
+                serviceAuthorization,
+                eventRequestData.getUserId(),
+                eventRequestData.getJurisdictionId(),
+                eventRequestData.getCaseTypeId(),
+                eventRequestData.isIgnoreWarning(),
+                caseDataContent
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/sscs/service/ccd/ReadCoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/sscs/service/ccd/ReadCoreCaseDataService.java
@@ -1,33 +1,33 @@
 package uk.gov.hmcts.sscs.service.ccd;
 
 import com.google.common.collect.ImmutableMap;
-
 import java.util.List;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.EventRequestData;
 import uk.gov.hmcts.sscs.model.ccd.CaseData;
 import uk.gov.hmcts.sscs.model.ccd.CcdUtil;
+import uk.gov.hmcts.sscs.service.idam.IdamService;
 
 @Service
 @Slf4j
 public class ReadCoreCaseDataService {
 
     private final CoreCaseDataService coreCaseDataService;
+    private final IdamService idamService;
 
     @Autowired
-    public ReadCoreCaseDataService(CoreCaseDataService coreCaseDataService) {
+    public ReadCoreCaseDataService(CoreCaseDataService coreCaseDataService,
+                                   IdamService idamService) {
         this.coreCaseDataService = coreCaseDataService;
+        this.idamService = idamService;
     }
 
     public CaseDetails getCcdCaseDetailsByCaseId(String caseId) {
         EventRequestData eventRequestData = coreCaseDataService.getEventRequestData("emptyEvent");
-        String serviceAuthorization = coreCaseDataService.generateServiceAuthorization();
+        String serviceAuthorization = idamService.generateServiceAuthorization();
 
         return getByCaseId(eventRequestData, serviceAuthorization, caseId);
     }
@@ -52,7 +52,7 @@ public class ReadCoreCaseDataService {
 
     public CaseDetails getCcdCaseDetailsByAppealNumber(String appealNumber) {
         EventRequestData eventRequestData = coreCaseDataService.getEventRequestData("emptyEvent");
-        String serviceAuthorization = coreCaseDataService.generateServiceAuthorization();
+        String serviceAuthorization = idamService.generateServiceAuthorization();
 
         List<CaseDetails> caseDetailsList = getByAppealNumber(eventRequestData, serviceAuthorization, appealNumber);
         CaseDetails caseDetails = null;

--- a/src/main/java/uk/gov/hmcts/sscs/service/ccd/UpdateCoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/sscs/service/ccd/UpdateCoreCaseDataService.java
@@ -1,31 +1,33 @@
 package uk.gov.hmcts.sscs.service.ccd;
 
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
 import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.EventRequestData;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.sscs.model.ccd.CaseData;
+import uk.gov.hmcts.sscs.service.idam.IdamService;
 
 @Service
 @Slf4j
 public class UpdateCoreCaseDataService {
 
     private final CoreCaseDataService coreCaseDataService;
+    private final IdamService idamService;
 
     @Autowired
-    public UpdateCoreCaseDataService(CoreCaseDataService coreCaseDataService) {
+    public UpdateCoreCaseDataService(CoreCaseDataService coreCaseDataService,
+                                     IdamService idamService) {
         this.coreCaseDataService = coreCaseDataService;
+        this.idamService = idamService;
     }
 
     public CaseDetails updateCcdCase(CaseData caseData, Long caseId, String eventId) {
         log.info("*** tribunals-service *** updateCcdCase ");
         EventRequestData eventRequestData = coreCaseDataService.getEventRequestData(eventId);
-        String serviceAuthorization = coreCaseDataService.generateServiceAuthorization();
+        String serviceAuthorization = idamService.generateServiceAuthorization();
         StartEventResponse startEventResponse = start(eventRequestData, serviceAuthorization, caseId);
 
         return create(eventRequestData, serviceAuthorization, coreCaseDataService.getCaseDataContent(caseData,

--- a/src/main/java/uk/gov/hmcts/sscs/service/idam/AuthTokenSubjectExtractor.java
+++ b/src/main/java/uk/gov/hmcts/sscs/service/idam/AuthTokenSubjectExtractor.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.sscs.service.idam;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.authorisation.exceptions.JwtDecodingException;
+
+@Service
+public class AuthTokenSubjectExtractor {
+
+    public String extract(String token) {
+        try {
+
+            DecodedJWT jwt = JWT.decode(
+                token.replaceFirst("^Bearer\\s+", "")
+            );
+
+            return jwt.getSubject();
+
+        } catch (JWTDecodeException e) {
+            throw new JwtDecodingException("Auth Token cannot be decoded", e);
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/sscs/service/idam/IdamService.java
+++ b/src/main/java/uk/gov/hmcts/sscs/service/idam/IdamService.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.sscs.service.idam;
+
+import java.util.Base64;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.sscs.ccd.properties.IdamProperties;
+import uk.gov.hmcts.sscs.model.idam.Authorize;
+
+@Service
+@Slf4j
+public class IdamService {
+
+    private final AuthTokenGenerator authTokenGenerator;
+    private final AuthTokenSubjectExtractor authTokenSubjectExtractor;
+    private final IdamApiClient idamApiClient;
+    private final IdamProperties idamProperties;
+
+    @Autowired
+    public IdamService(AuthTokenGenerator authTokenGenerator, AuthTokenSubjectExtractor authTokenSubjectExtractor,
+                       IdamApiClient idamApiClient, IdamProperties idamProperties) {
+        this.authTokenGenerator = authTokenGenerator;
+        this.authTokenSubjectExtractor = authTokenSubjectExtractor;
+        this.idamApiClient = idamApiClient;
+        this.idamProperties = idamProperties;
+    }
+
+    public String generateServiceAuthorization() {
+        return authTokenGenerator.generate();
+    }
+
+    public String getUserId(String oauth2Token) {
+        return authTokenSubjectExtractor.extract(oauth2Token);
+    }
+
+    public String getIdamOauth2Token() {
+        String authorisation = idamProperties.getOauth2().getUser().getEmail()
+            + ":" + idamProperties.getOauth2().getUser().getPassword();
+        String base64Authorisation = Base64.getEncoder().encodeToString(authorisation.getBytes());
+
+        Authorize authorize = idamApiClient.authorizeCodeType(
+            "Basic " + base64Authorisation,
+            "code",
+            idamProperties.getOauth2().getClient().getId(),
+            idamProperties.getOauth2().getRedirectUrl()
+        );
+
+        Authorize authorizeToken = idamApiClient.authorizeToken(
+            authorize.getCode(),
+            "authorization_code",
+            idamProperties.getOauth2().getRedirectUrl(),
+            idamProperties.getOauth2().getClient().getId(),
+            idamProperties.getOauth2().getClient().getSecret()
+        );
+
+        return "Bearer " + authorizeToken.getAccessToken();
+    }
+}

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -24,7 +24,6 @@ spring.application.name=TribunalsCaseApi
 
 # CCD
 core_case_data.api.url=${CORE_CASE_DATA_API_URL:http://localhost:4452}
-core_case_data.userId=${CORE_CASE_DATA_USER_ID:16}
 core_case_data.jurisdictionId=${CORE_CASE_DATA_JURISDICTION_ID:SSCS}
 core_case_data.caseTypeId=${CORE_CASE_DATA_CASE_TYPE_ID:Benefit}
 

--- a/src/test/java/uk/gov/hmcts/sscs/service/ccd/CreateCoreCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/service/ccd/CreateCoreCaseDataServiceTest.java
@@ -2,7 +2,10 @@ package uk.gov.hmcts.sscs.service.ccd;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -11,13 +14,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.EventRequestData;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.sscs.model.ccd.CaseData;
+import uk.gov.hmcts.sscs.service.idam.IdamService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CreateCoreCaseDataServiceTest {
@@ -25,13 +28,17 @@ public class CreateCoreCaseDataServiceTest {
     @Mock
     private CoreCaseDataApi coreCaseDataApiMock;
     @Mock
+    private IdamService idamServiceMock;
+    @Mock
     private CoreCaseDataService coreCaseDataServiceMock;
 
     private CreateCoreCaseDataService createCoreCaseDataService;
 
     @Before
     public void setUp() {
-        createCoreCaseDataService = new CreateCoreCaseDataService(coreCaseDataServiceMock);
+        createCoreCaseDataService = new CreateCoreCaseDataService(
+            coreCaseDataServiceMock, idamServiceMock
+        );
     }
 
     @Test
@@ -41,7 +48,7 @@ public class CreateCoreCaseDataServiceTest {
         mockCaseDetails();
         when(coreCaseDataServiceMock.getEventRequestData(eq("appealCreated")))
                 .thenReturn(EventRequestData.builder().build());
-        when(coreCaseDataServiceMock.generateServiceAuthorization())
+        when(idamServiceMock.generateServiceAuthorization())
                 .thenReturn("s2s token");
         when(coreCaseDataServiceMock.getCaseDataContent(
                 any(CaseData.class),

--- a/src/test/java/uk/gov/hmcts/sscs/service/ccd/ReadCoreCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/service/ccd/ReadCoreCaseDataServiceTest.java
@@ -2,7 +2,9 @@ package uk.gov.hmcts.sscs.service.ccd;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -11,10 +13,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.EventRequestData;
 import uk.gov.hmcts.sscs.model.ccd.CaseData;
+import uk.gov.hmcts.sscs.service.idam.IdamService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ReadCoreCaseDataServiceTest {
@@ -22,13 +24,17 @@ public class ReadCoreCaseDataServiceTest {
     @Mock
     private CoreCaseDataApi coreCaseDataApiMock;
     @Mock
+    private IdamService idamServiceMock;
+    @Mock
     private CoreCaseDataService coreCaseDataServiceMock;
 
     private ReadCoreCaseDataService readCoreCaseDataService;
 
     @Before
     public void setUp() {
-        readCoreCaseDataService = new ReadCoreCaseDataService(coreCaseDataServiceMock);
+        readCoreCaseDataService = new ReadCoreCaseDataService(
+            coreCaseDataServiceMock, idamServiceMock
+        );
     }
 
     @Test
@@ -38,7 +44,7 @@ public class ReadCoreCaseDataServiceTest {
                 anyString())).thenReturn(CaseDataUtils.buildCaseDetails());
         when(coreCaseDataServiceMock.getEventRequestData(eq("emptyEvent")))
                 .thenReturn(EventRequestData.builder().build());
-        when(coreCaseDataServiceMock.generateServiceAuthorization())
+        when(idamServiceMock.generateServiceAuthorization())
                 .thenReturn("s2s token");
         when(coreCaseDataServiceMock.getCoreCaseDataApi()).thenReturn(coreCaseDataApiMock);
 
@@ -59,7 +65,7 @@ public class ReadCoreCaseDataServiceTest {
                 anyMap())).thenReturn(CaseDataUtils.buildCaseDetailsList());
         when(coreCaseDataServiceMock.getEventRequestData(eq("emptyEvent")))
                 .thenReturn(EventRequestData.builder().build());
-        when(coreCaseDataServiceMock.generateServiceAuthorization())
+        when(idamServiceMock.generateServiceAuthorization())
                 .thenReturn("s2s token");
         when(coreCaseDataServiceMock.getCoreCaseDataApi()).thenReturn(coreCaseDataApiMock);
 

--- a/src/test/java/uk/gov/hmcts/sscs/service/ccd/UpdateCoreCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/service/ccd/UpdateCoreCaseDataServiceTest.java
@@ -2,7 +2,10 @@ package uk.gov.hmcts.sscs.service.ccd;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -11,13 +14,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.EventRequestData;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.sscs.model.ccd.CaseData;
+import uk.gov.hmcts.sscs.service.idam.IdamService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UpdateCoreCaseDataServiceTest {
@@ -25,13 +28,17 @@ public class UpdateCoreCaseDataServiceTest {
     @Mock
     private CoreCaseDataApi coreCaseDataApiMock;
     @Mock
+    private IdamService idamServiceMock;
+    @Mock
     private CoreCaseDataService coreCaseDataServiceMock;
 
     private UpdateCoreCaseDataService updateCoreCaseDataService;
 
     @Before
     public void setUp() {
-        updateCoreCaseDataService = new UpdateCoreCaseDataService(coreCaseDataServiceMock);
+        updateCoreCaseDataService = new UpdateCoreCaseDataService(
+            coreCaseDataServiceMock, idamServiceMock
+        );
     }
 
     @Test
@@ -41,7 +48,7 @@ public class UpdateCoreCaseDataServiceTest {
         mockCaseDetails();
         when(coreCaseDataServiceMock.getEventRequestData(anyString()))
                 .thenReturn(EventRequestData.builder().build());
-        when(coreCaseDataServiceMock.generateServiceAuthorization())
+        when(idamServiceMock.generateServiceAuthorization())
                 .thenReturn("s2s token");
         when(coreCaseDataServiceMock.getCaseDataContent(
                 any(CaseData.class),

--- a/src/test/java/uk/gov/hmcts/sscs/service/idam/AuthTokenSubjectExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/service/idam/AuthTokenSubjectExtractorTest.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.sscs.service.idam;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.authorisation.exceptions.JwtDecodingException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuthTokenSubjectExtractorTest {
+
+    private AuthTokenSubjectExtractor authTokenSubjectExtractor;
+
+    @Before
+    public void setUp() {
+        authTokenSubjectExtractor = new AuthTokenSubjectExtractor();
+    }
+
+    @Test
+    public void shouldExtractSubjectFromJwt() {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1"
+                       + "NiJ9.eyJzdWIiOiIxNiIsIm5hbWUiOiJ"
+                       + "UZXN0IiwianRpIjoiMTIzNCIsImlhdCI"
+                       + "6MTUyNjkyOTk1MiwiZXhwIjoxNTI2OTM"
+                       + "zNTg5fQ.lZwrWNjG-y1Olo1qWocKIuq3"
+                       + "_fdffVF8BTcR5l87FTg";
+
+        assertThat(authTokenSubjectExtractor.extract(token), is("16"));
+    }
+
+    @Test
+    public void shouldExtractSubjectFromJwtWithBearerType() {
+        String token = "Bearer "
+                       + "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1"
+                       + "NiJ9.eyJzdWIiOiIxNiIsIm5hbWUiOiJ"
+                       + "UZXN0IiwianRpIjoiMTIzNCIsImlhdCI"
+                       + "6MTUyNjkyOTk1MiwiZXhwIjoxNTI2OTM"
+                       + "zNTg5fQ.lZwrWNjG-y1Olo1qWocKIuq3"
+                       + "_fdffVF8BTcR5l87FTg";
+
+        assertThat(authTokenSubjectExtractor.extract(token), is("16"));
+    }
+
+    @Test(expected = JwtDecodingException.class)
+    public void shouldThrowForMalformedJwt() {
+        authTokenSubjectExtractor.extract("badgers");
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/sscs/service/idam/IdamServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/service/idam/IdamServiceTest.java
@@ -1,0 +1,87 @@
+package uk.gov.hmcts.sscs.service.idam;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Base64;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.sscs.ccd.properties.IdamProperties;
+import uk.gov.hmcts.sscs.model.idam.Authorize;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IdamServiceTest {
+
+    @Mock
+    private AuthTokenGenerator authTokenGenerator;
+    @Mock
+    private AuthTokenSubjectExtractor authTokenSubjectExtractor;
+    @Mock
+    private IdamApiClient idamApiClient;
+
+    private Authorize authToken;
+    private IdamProperties idamProperties;
+    private IdamService idamService;
+
+    @Before
+    public void setUp() {
+        authToken = new Authorize("redirect/", "authCode", "access");
+        idamProperties = new IdamProperties();
+        idamService = new IdamService(
+            authTokenGenerator, authTokenSubjectExtractor, idamApiClient, idamProperties
+        );
+    }
+
+    @Test
+    public void shouldReturnAuthTokenGivenNewRequest() {
+        String auth = "auth";
+        when(authTokenGenerator.generate()).thenReturn(auth);
+        assertThat(idamService.generateServiceAuthorization(), is(auth));
+    }
+
+    @Test
+    public void shouldReturnServiceUserIdGivenAuthToken() {
+        String auth = "token_with_sub_16";
+        String userId = "16";
+        when(authTokenSubjectExtractor.extract(auth)).thenReturn(userId);
+        assertThat(idamService.getUserId(auth), is(userId));
+    }
+
+    @Test
+    public void shouldReturnIdamTokenGivenRequestForS2S() {
+        IdamProperties.Oauth2 oauth2 = new IdamProperties.Oauth2();
+        IdamProperties.Oauth2.User user = new IdamProperties.Oauth2.User();
+        user.setEmail("email");
+        user.setPassword("pass");
+        oauth2.setUser(user);
+        IdamProperties.Oauth2.Client client = new IdamProperties.Oauth2.Client();
+        client.setId("id");
+        client.setSecret("secret");
+        oauth2.setClient(client);
+        oauth2.setRedirectUrl("redirect/");
+        idamProperties.setOauth2(oauth2);
+
+        String base64Authorisation = Base64.getEncoder().encodeToString("email:pass".getBytes());
+
+        when(idamApiClient.authorizeCodeType("Basic " + base64Authorisation,
+            "code",
+            "id",
+            "redirect/")).thenReturn(authToken);
+
+        when(idamApiClient.authorizeToken(authToken.getCode(),
+            "authorization_code",
+            "redirect/",
+            "id",
+            "secret")).thenReturn(authToken);
+
+        String token = idamService.getIdamOauth2Token();
+
+        assertThat(token, containsString("Bearer access"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/sscs/util/SerializeJsonMessageManager.java
+++ b/src/test/java/uk/gov/hmcts/sscs/util/SerializeJsonMessageManager.java
@@ -49,14 +49,14 @@ public enum SerializeJsonMessageManager {
     private final String serializedMessage;
 
     SerializeJsonMessageManager(String fileName) {
-        this.serializedMessage = getSerialisedMessage(fileName, "tya/");
+        this.serializedMessage = getSerialisedMessage(fileName);
     }
 
     private String getSerialisedMessage(String fileName) {
         try {
 
             ClassLoader classLoader = getClass().getClassLoader();
-            File file = new File(classLoader.getResource(path + fileName).getFile());
+            File file = new File(classLoader.getResource("tya/" + fileName).getFile());
             return new String(Files.readAllBytes(file.toPath()));
 
         } catch (IOException e) {

--- a/src/test/java/uk/gov/hmcts/sscs/util/SerializeJsonMessageManager.java
+++ b/src/test/java/uk/gov/hmcts/sscs/util/SerializeJsonMessageManager.java
@@ -2,14 +2,11 @@ package uk.gov.hmcts.sscs.util;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
-
 import lombok.Getter;
 import lombok.ToString;
-
 import uk.gov.hmcts.sscs.model.ccd.CaseData;
 
 @Getter
@@ -52,12 +49,16 @@ public enum SerializeJsonMessageManager {
     private final String serializedMessage;
 
     SerializeJsonMessageManager(String fileName) {
-        this.serializedMessage = getSerialisedMessage(fileName);
+        this.serializedMessage = getSerialisedMessage(fileName, "tya/");
     }
 
     private String getSerialisedMessage(String fileName) {
         try {
-            return new String(Files.readAllBytes(Paths.get("src/test/resources/tya/" + fileName)));
+
+            ClassLoader classLoader = getClass().getClassLoader();
+            File file = new File(classLoader.getResource(path + fileName).getFile());
+            return new String(Files.readAllBytes(file.toPath()));
+
         } catch (IOException e) {
             e.printStackTrace();
             throw new RuntimeException();


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-2877

### Change description ###

IDAM user_id is taken from the Authorisation token, instead of being loaded from application configuration.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```