### PR TITLE
SSCS-3687 Log tribunal errors correctly

### DIFF
--- a/src/main/java/uk/gov/hmcts/sscs/controller/PostCodeController.java
+++ b/src/main/java/uk/gov/hmcts/sscs/controller/PostCodeController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.sscs.exception.AirLookupServiceException;
 import uk.gov.hmcts.sscs.service.AirLookupService;
 
 /**
@@ -35,7 +36,9 @@ public class PostCodeController {
         String regionalCentre = airLookupService.lookupRegionalCentre(postCode);
 
         if (regionalCentre == null) {
-            LOG.error("Could not find postcode " + postCode);
+            String message = "Could not find postcode " + postCode;
+            AirLookupServiceException ex = new AirLookupServiceException(new Exception(message));
+            LOG.error(message, ex);
             return notFound().build();
         }
 

--- a/src/main/java/uk/gov/hmcts/sscs/exception/AirLookupServiceException.java
+++ b/src/main/java/uk/gov/hmcts/sscs/exception/AirLookupServiceException.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.sscs.exception;
+
+import uk.gov.hmcts.reform.logging.exception.AlertLevel;
+import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
+
+@SuppressWarnings("squid:MaximumInheritanceDepth")
+public class AirLookupServiceException extends UnknownErrorCodeException {
+    public AirLookupServiceException(Throwable cause) {
+        super(AlertLevel.P3, cause);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/sscs/service/AirLookupService.java
+++ b/src/main/java/uk/gov/hmcts/sscs/service/AirLookupService.java
@@ -13,6 +13,7 @@ import org.apache.poi.ss.usermodel.*;
 import org.slf4j.Logger;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.sscs.exception.AirLookupServiceException;
 
 /**
  * Service that ingests a spreadsheet and a csv file containing the
@@ -69,7 +70,9 @@ public class AirLookupService {
             LOG.debug("Air Venue data has " + lookupAirVenueNameByPostCode.keySet().size() + " post codes");
 
         } catch (IOException e) {
-            LOG.error("Unable to read in spreadsheet with post code data: reference-data/AIRLookup RC.xls", e);
+            String message = "Unable to read in spreadsheet with post code data: reference-data/AIRLookup RC.xls";
+            AirLookupServiceException ex = new AirLookupServiceException(e);
+            LOG.error(message, ex);
         }
         try {
             ClassPathResource classPathResource = new ClassPathResource(CSV_FILE_PATH);
@@ -78,7 +81,9 @@ public class AirLookupService {
 
             LOG.debug("Venue map has " + lookupAirVenueNameByPostCode.keySet().size() + " venue ids");
         } catch (IOException e) {
-            LOG.error("Unable to read in csv with post code - venue id data: reference-data/airLookupVenueIds.csv", e);
+            String message = "Unable to read in csv with post code - venue id data: reference-data/airLookupVenueIds.csv";
+            AirLookupServiceException ex = new AirLookupServiceException(e);
+            LOG.error(message, ex);
         }
     }
 
@@ -115,7 +120,9 @@ public class AirLookupService {
                                     lookupAirVenueNameByPostCode.put(postcodeCell.getRichStringCellValue().getString().toLowerCase(),
                                             venueName.substring(0, venueName.indexOf(venueNameSplitChar)).trim());
                                 } else {
-                                    LOG.error("Unknown venue name type" + venueName);
+                                    String message = "Unknown venue name type" + venueName;
+                                    AirLookupServiceException ex = new AirLookupServiceException(new Exception(message));
+                                    LOG.error(message, ex);
                                 }
                             }
                         }


### PR DESCRIPTION
- Errors need to be logged in a certain way in order for app insights to correctly report. Fixed the AirLookup exceptions to comply with what is required