### PR TITLE
[PREVIEW] SSCS-3816 Handle empty events

### DIFF
--- a/src/main/java/uk/gov/hmcts/sscs/builder/TrackYourAppealJsonBuilder.java
+++ b/src/main/java/uk/gov/hmcts/sscs/builder/TrackYourAppealJsonBuilder.java
@@ -50,6 +50,7 @@ public class TrackYourAppealJsonBuilder {
         }
 
         createEvidenceResponseEvents(caseData);
+        caseData.getEvents().removeIf(a -> a.getValue().getDate() == null);
         eventList = caseData.getEvents();
         eventList.sort(Comparator.reverseOrder());
         processExceptions(eventList);

--- a/src/test/java/uk/gov/hmcts/sscs/builder/TrackYourAppealJsonBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/builder/TrackYourAppealJsonBuilderTest.java
@@ -181,6 +181,14 @@ public class TrackYourAppealJsonBuilderTest {
         assertJsonEquals(LAPSED_REVISED.getSerializedMessage(), objectNode);
     }
 
+    @Test
+    public void emptyEventDateShouldBeIgnoredTest() throws CcdException {
+        CaseData caseData = EMPTY_EVENT_CCD.getDeserializeMessage();
+        ObjectNode objectNode = trackYourAppealJsonBuilder.build(caseData,
+                populateRegionalProcessingCenter());
+        assertJsonEquals(LAPSED_REVISED.getSerializedMessage(), objectNode);
+    }
+
     @Test(expected = CcdException.class)
     public void noEventsTest() throws CcdException {
         CaseData caseData = NO_EVENTS_CCD.getDeserializeMessage();

--- a/src/test/java/uk/gov/hmcts/sscs/util/SerializeJsonMessageManager.java
+++ b/src/test/java/uk/gov/hmcts/sscs/util/SerializeJsonMessageManager.java
@@ -41,6 +41,7 @@ public enum SerializeJsonMessageManager {
     CLOSED_CCD("closedCcd.json"),
     LAPSED_REVISED("lapsedRevised.json"),
     LAPSED_REVISED_CCD("lapsedRevisedCcd.json"),
+    EMPTY_EVENT_CCD("emptyEventCcd.json"),
     NO_EVENTS_CCD("noEventsCcd.json"),
     APPEAL_CREATED("appealCreated.json"),
     APPEAL_CREATED_CCD("appealCreatedCcd.json"),

--- a/src/test/resources/tya/emptyEventCcd.json
+++ b/src/test/resources/tya/emptyEventCcd.json
@@ -1,0 +1,74 @@
+{
+  "caseReference": "SC333/33/33333",
+  "appeal": {
+    "appellant": {
+      "name": {
+        "title": "Mr.",
+        "lastName": "Charlie",
+        "firstName": "C"
+      }
+    },
+    "benefitType": {
+      "code": "PIP"
+    }
+  },
+  "hearings": [{
+    "value": {
+      "venue": {
+        "name": "Prudential House",
+        "address": {
+          "line1": "36 Dale Street",
+          "line2": "",
+          "town": "Liverpool",
+          "postcode": "L2 5UZ"
+        },
+        "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+      },
+      "hearingDate": "2017-07-17",
+      "time": "23:00",
+      "eventDate": "2017-01-20T18:15:06.223"
+    }
+  }],
+  "events": [
+    {
+      "value": {
+        "date": "2017-03-02T17:27:50.297",
+        "type": "appealLapsed",
+        "description": "Lapsed revised"
+      }
+    },
+    {
+      "value": {
+        "date": "2017-01-20T15:15:06.223",
+        "type": "hearingBooked",
+        "description": "Hearing booked"
+      }
+    },
+    {
+      "value": {
+        "date": "2016-11-03T15:11:45.827",
+        "type": "responseReceived",
+        "description": "Dwp Respond"
+      }
+    },
+    {
+      "value": {
+        "date": "2016-09-29T08:32:44.633",
+        "type": "appealReceived",
+        "description": "Appeal received"
+      }
+    },
+    {
+      "value": {
+        "date": null,
+        "type": "",
+        "description": null
+      }
+    }
+  ],
+  "subscriptions": {
+    "appellantSubscription": {
+      "tya": "abcde12345"
+    }
+  }
+}


### PR DESCRIPTION
- When an empty event (date) comes back from CCD for TYA then remove these events so no NPE is thrown on sort