### PR TITLE
[PREVIEW] SSCS-3805 Prevent duplicate CCD appeals

### DIFF
--- a/src/IntegrationTests/java/uk/gov/hmcts/sscs/service/ReadCcdServiceRetryAndRecoverTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/sscs/service/ReadCcdServiceRetryAndRecoverTest.java
@@ -93,18 +93,27 @@ public class ReadCcdServiceRetryAndRecoverTest {
     @Test
     public void givenFindCaseDataByAppealNumberFails_shouldRetryAndRecover() {
         CaseData result = readCcdService.getCcdCaseDataByAppealNumber(CASE_REF);
-        verifyTest();
+        verifySearchForCaseworkersWereCalled();
         assertEquals(CASE_REF, CcdUtil.getCaseData(result).getCaseReference());
     }
 
     @Test
     public void givenFindCaseDetailsByAppealNumberFails_shouldRetryAndRecover() {
         CaseDetails result = readCcdService.getCcdCaseDetailsByAppealNumber(CASE_REF);
-        verifyTest();
+        verifySearchForCaseworkersWereCalled();
         assertTrue(result.getId() == 10L);
     }
 
-    private void verifyTest() {
+    @Test
+    public void givenFindCaseDetailsByByNinoAndBenefitTypeAndMrnDateFails_shouldRetryAndRecover() {
+        CaseDetails result = readCcdService.getCcdCaseByNinoAndBenefitTypeAndMrnDate("JT01234567B", "JSA", "02/08/2018");
+
+        verifySearchForCaseworkersWereCalled();
+
+        assertTrue(result.getId() == 10L);
+    }
+
+    private void verifySearchForCaseworkersWereCalled() {
 
         verify(coreCaseDataApi)
             .searchForCaseworker(

--- a/src/main/java/uk/gov/hmcts/sscs/service/CcdService.java
+++ b/src/main/java/uk/gov/hmcts/sscs/service/CcdService.java
@@ -55,12 +55,15 @@ public class CcdService {
     }
 
     public CaseDetails findCcdCaseByNinoAndBenefitTypeAndMrnDate(CaseData caseData) {
-        try {
-            return readCoreCaseDataService.getCcdCaseByNinoAndBenefitTypeAndMrnDate(
-                    caseData.getGeneratedNino(), caseData.getAppeal().getBenefitType().getCode(), caseData.getAppeal().getMrnDetails().getMrnDate());
-        } catch (Exception ex) {
-            throw logCcdException("Error while getting case from ccd", ex);
+        if (caseData.getAppeal().getMrnDetails().getMrnDate() != null) {
+            try {
+                return readCoreCaseDataService.getCcdCaseByNinoAndBenefitTypeAndMrnDate(
+                        caseData.getGeneratedNino(), caseData.getAppeal().getBenefitType().getCode(), caseData.getAppeal().getMrnDetails().getMrnDate());
+            } catch (Exception ex) {
+                throw logCcdException("Error while getting case from ccd", ex);
+            }
         }
+        return null;
     }
 
     public CaseData findCcdCaseByAppealNumber(String appealNumber) {

--- a/src/main/java/uk/gov/hmcts/sscs/service/CcdService.java
+++ b/src/main/java/uk/gov/hmcts/sscs/service/CcdService.java
@@ -54,6 +54,15 @@ public class CcdService {
         }
     }
 
+    public CaseDetails findCcdCaseByNinoAndBenefitTypeAndMrnDate(CaseData caseData) {
+        try {
+            return readCoreCaseDataService.getCcdCaseByNinoAndBenefitTypeAndMrnDate(
+                    caseData.getGeneratedNino(), caseData.getAppeal().getBenefitType().getCode(), caseData.getAppeal().getMrnDetails().getMrnDate());
+        } catch (Exception ex) {
+            throw logCcdException("Error while getting case from ccd", ex);
+        }
+    }
+
     public CaseData findCcdCaseByAppealNumber(String appealNumber) {
         try {
             return readCoreCaseDataService.getCcdCaseDataByAppealNumber(appealNumber);

--- a/src/main/java/uk/gov/hmcts/sscs/service/SubmitAppealService.java
+++ b/src/main/java/uk/gov/hmcts/sscs/service/SubmitAppealService.java
@@ -160,10 +160,16 @@ public class SubmitAppealService {
 
     private CaseDetails createCaseInCcd(CaseData caseData) {
         try {
-            CaseDetails caseDetails = ccdService.createCase(caseData);
-            log.info("Appeal successfully created in CCD for Nino - {} and benefit type {}",
-                    caseData.getGeneratedNino(), caseData.getAppeal().getBenefitType().getCode());
-            return caseDetails;
+            CaseDetails caseDetails = ccdService.findCcdCaseByNinoAndBenefitTypeAndMrnDate(caseData);
+            if (caseDetails == null) {
+                caseDetails = ccdService.createCase(caseData);
+                log.info("Appeal successfully created in CCD for Nino - {} and benefit type {}",
+                        caseData.getGeneratedNino(), caseData.getAppeal().getBenefitType().getCode());
+                return caseDetails;
+            } else {
+                log.info("Duplicate case found for Nino {} and benefit type {} so not creating in CCD", caseData.getGeneratedNino(), caseData.getAppeal().getBenefitType().getCode());
+                return caseDetails;
+            }
         } catch (CcdException ccdEx) {
             log.error("Failed to create ccd case for Nino - {} and Benefit type - {} but carrying on ",
                     caseData.getGeneratedNino(), caseData.getAppeal().getBenefitType().getCode(), ccdEx);

--- a/src/main/java/uk/gov/hmcts/sscs/service/ccd/ReadCoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/sscs/service/ccd/ReadCoreCaseDataService.java
@@ -58,4 +58,29 @@ public class ReadCoreCaseDataService {
                 ImmutableMap.of("case.subscriptions.appellantSubscription.tya", appealNumber)
         );
     }
+
+    @Retryable
+    public CaseDetails getCcdCaseByNinoAndBenefitTypeAndMrnDate(String nino, String benefitType, String mrnDate) {
+        log.info("*** tribunals-service *** get case details by nino and benefit type and mrn date {}, {}, {}", nino, benefitType, mrnDate);
+        EventRequestData eventRequestData = coreCaseDataService.getEventRequestData("emptyEvent");
+        String serviceAuthorization = idamService.generateServiceAuthorization();
+
+        List<CaseDetails> caseDetailsList = getByNinoAndBenefitTypeAndMrnDate(eventRequestData, serviceAuthorization, nino, benefitType, mrnDate);
+        return !caseDetailsList.isEmpty() ? caseDetailsList.get(0) : null;
+    }
+
+    private List<CaseDetails> getByNinoAndBenefitTypeAndMrnDate(EventRequestData eventRequestData, String serviceAuthorization,
+                                                                String nino, String benefitType, String mrnDate) {
+        log.info("Get getByNinoAndBenefitTypeAndMrnDate {}, {}, {} ...", nino, benefitType, mrnDate);
+        return coreCaseDataService.getCoreCaseDataApi().searchForCaseworker(
+                eventRequestData.getUserToken(),
+                serviceAuthorization,
+                eventRequestData.getUserId(),
+                eventRequestData.getJurisdictionId(),
+                eventRequestData.getCaseTypeId(),
+                ImmutableMap.of("case.generatedNino", nino,
+                        "case.appeal.benefitType.code", benefitType,
+                        "case.appeal.mrnDetails.mrnDate", mrnDate)
+        );
+    }
 }


### PR DESCRIPTION
- If a case with same nino, benefit type and mrn date already exists in CCD then prevent it from being added again
- Continue to Robotics and PDF as duplicates are handled on their side anyway